### PR TITLE
Grammatical/name fixes to pgBackRest Katacoda.

### DIFF
--- a/pg-administration/basic-postgresql-for-dbas/pgbackrest/10-pg-setup.md
+++ b/pg-administration/basic-postgresql-for-dbas/pgbackrest/10-pg-setup.md
@@ -1,11 +1,11 @@
-`pg_basebackup` is included with PostgreSQL and is great for many filesystem backup scenarios. However, it can be lacking in many advanced features that enterprise backup solutions require; incrementals & differentials, retention management, parallelism, and more. pgBaseBackup is a third-party tool that aims to provide these advanced features and much more!
+`pg_basebackup` is included with PostgreSQL and is great for many filesystem backup scenarios. However, it can be lacking in many advanced features that enterprise backup solutions require; incrementals & differentials, retention management, parallelism, and more. pgBackRest is a third-party tool that aims to provide these advanced features and much more!
 
 pgBackrest is available in the PGDG Yum repositories. These have already been set up in this scenario, so it's just a matter of installing the package
 
 ```
 sudo yum install -y pgbackrest
 ```{{execute T1}}
-Next some settings in the postgresql.conf must be updated to ensure WAL archiving is working. `archive_mode` must be turned on and the `archive_command` must be set to use backrest's `archive-push` command. A stanza name for the pgbackrest repo must also be given and that will be set up in the next step. Since we're changing these values on a running system, the ALTER SYSTEM command can be used
+Next some settings in the postgresql.conf must be updated to ensure WAL archiving is working. `archive_mode` must be turned on and the `archive_command` must be set to use pgBackRest's `archive-push` command. A stanza name for the pgBackRest repo must also be given and that will be set up in the next step. Since we're changing these values on a running system, the ALTER SYSTEM command can be used
 ```
 psql -c "ALTER SYSTEM SET archive_mode = 'on'"
 ```{{execute T1}}
@@ -16,10 +16,6 @@ Archive mode isn't typically turned on by default and changing this setting requ
 ```
 sudo systemctl restart postgresql-11
 ```{{execute T1}}
-You may see errors in the postgresql logs about the archive_command failing. This is normal and should resolve itself once the pgbackrest repository is set up. Do note that until the errors subside, the database will retain all WAL files generated in the `pg_wal` folder until it succeeds. In the case where the pgbackrest repo may not be available yet for an extended period of time, the easiest thing to do is to set `archive_command = '/bin/true'` until then. The command itself only requires a reload of the database to change, so that allows you to at least enable `archive_mode` until it's ready.
+You may see errors in the postgresql logs about the archive_command failing. This is normal and should resolve itself once the pgBackRest repository is set up. Do note that until the errors subside, the database will retain all WAL files generated in the `pg_wal` folder until it succeeds. In the case where the pgBackRest repo may not be available for an extended period of time, the easiest thing to do is to set `archive_command = '/bin/true'` until then. The command itself only requires a reload of the database to change, so that allows you to at least enable `archive_mode` until it's ready.
 
-Next is configuring pgbackrest itself.
-
-
-
-
+Next is configuring pgBackRest itself.

--- a/pg-administration/basic-postgresql-for-dbas/pgbackrest/20-backrest-setup.md
+++ b/pg-administration/basic-postgresql-for-dbas/pgbackrest/20-backrest-setup.md
@@ -1,4 +1,4 @@
-A minimal `/etc/pgbackrest.conf` file is created by the package installation. We will be configuring a global section for settings that are common to all stanzas. And then some stanza specific settings. It's also possible to group settings into sections for specific commands as well. You can either run the command below or manually edit the config file yourself 
+A minimal `/etc/pgbackrest.conf` file is created by the package installation. We will be configuring a global section for settings that are common to all stanzas. And then some stanza specific settings. It's also possible to group settings into sections for specific commands as well. You can either run the command below or manually edit the config file yourself
 ```
 sudo bash -c "cat > /etc/pgbackrest.conf << EOF
 [global]
@@ -11,19 +11,16 @@ retention-full=2
 EOF"
 ```{{execute T1}}
 
-The `global` section has settings for the pgbackrest repository that will be common for any stanzas that are created. This is very useful when you have a dedicated backup system for many databases that should have some common settings such as the repository location and logging levels. The log level is also slightly increased from the default to give slightly more feedback when running commands manually.
+The `global` section has settings for the pgBackRest repository that will be common for any stanzas that are created. This is very useful when you have a dedicated backup system for many databases that should have some common settings such as the repository location and logging levels. The log level is also slightly increased from the default to give slightly more feedback when running commands manually.
 
-Each stanza's settings are then placed under a `[stanza-name]` heading. In this case, it contains the path to our database's data directory and our retenion policy. Here it is keeping 2 full backups. When the next ***successful*** backup exceeds this number, pgbackrest will automatically expire older backups.
+Each stanza's settings are then placed under a `[stanza-name]` heading. In this case, it contains the path to our database's data directory and our retention policy. Here it is keeping 2 full backups. When the next ***successful*** backup exceeds this number, pgBackRest will automatically expire older backups.
 
 With the configuration in place, the stanza can now be created in our repository. You'll typically be wanting to run the backups as the postgres system user, not root. The archive_command is run as the postgres system user, so it needs to be able to write to the repository. And then this allows the backups to be run as the postgres user as well, without requiring root.
 ```
 sudo -Hiu postgres pgbackrest --stanza=main stanza-create
 ```{{execute T1}}
-It's then good to run the check command to ensure pgbackrest is configured and working properly
+It's then good to run the check command to ensure pgBackRest is configured and working properly
 ```
 sudo -Hiu postgres pgbackrest --stanza=main check
 ```{{execute T1}}
-If either of these commands fail, you can check the pgbackrest logs located in `/var/log/pgbackrest` by default. If the issue is with the archive command, additional informaton as to why it's failing can also be found in the postgresql logs themselves (`/var/lib/pgsql/11/data/log`).
-
-
-
+If either of these commands fail, you can check the pgBackRest logs located in `/var/log/pgbackrest` by default. If the issue is with the archive command, additional information as to why it's failing can also be found in the postgresql logs themselves (`/var/lib/pgsql/11/data/log`).

--- a/pg-administration/basic-postgresql-for-dbas/pgbackrest/30-running-backup.md
+++ b/pg-administration/basic-postgresql-for-dbas/pgbackrest/30-running-backup.md
@@ -12,7 +12,3 @@ Run the above two commands a few more times. If you cause more than 2 fulls to b
 ```
 sudo -Hiu postgres pgbackrest info
 ```{{execute T1}}
-
-
-
-

--- a/pg-administration/basic-postgresql-for-dbas/pgbackrest/40-backrest-restore.md
+++ b/pg-administration/basic-postgresql-for-dbas/pgbackrest/40-backrest-restore.md
@@ -1,6 +1,6 @@
-If we need to restore our backups at any time, say due to a dropped table, pgbackrest allows that to be done very efficiently. And with Point-In-Time recovery, we can restore the database to a specific time we know that it was in a good state.
+If we need to restore our backups at any time, say due to a dropped table, pgBackRest allows that to be done very efficiently. And with Point-In-Time recovery, we can restore the database to a specific time when we know that it was in a good state.
 
-We'll need to know the time before our table was dropped for this example, so we'll make note of that now using an environment variable to be used later. It is important to represent the time as reckoned by PostgreSQL and to include timezone offsets. This reduces the possibility of unintended timezone conversions and an unexpected recovery result. 
+We'll need to know the time before our table was dropped for this example, so we'll make note of that now using an environment variable to be used later. It is important to represent the time as reckoned by PostgreSQL and to include timezone offsets. This reduces the possibility of unintended timezone conversions and an unexpected recovery result.
 ```
 export RESTORETIME=$(psql -Atc "select current_timestamp")
 echo $RESTORETIME
@@ -15,7 +15,7 @@ We're now in disaster recovery mode, so we'll want to shut down our primary data
 ```
 sudo systemctl stop postgresql-11
 ```{{execute T1}}
-Note that the last backup is always used by default when running the restore command. If the last backup happened after the desired point in time, the `--set` command can be given to pgbackrest to tell it to use an earlier backup that still exists in the repository. Also by default, the restore location must be empty. But if we're restoring to an existing cluster, the `--delta` option can be used to just overwrite what has changed since the last backup. This can GREATLY speed up recovery times.
+Note that the last backup is always used by default when running the restore command. If the last backup happened after the desired point in time, the `--set` command can be given to pgBackRest to tell it to use an earlier backup that still exists in the repository. Also by default, the restore location must be empty. But if we're restoring to an existing cluster, the `--delta` option can be used to just overwrite what has changed since the last backup. This can GREATLY speed up recovery times.
 ```
 sudo -Hiu postgres pgbackrest --stanza=main --delta --type=time "--target=$RESTORETIME" --target-action=promote restore
 ```{{execute T1}}
@@ -39,6 +39,6 @@ sudo -Hiu postgres chmod 700 /var/lib/pgsql/11/br_restore
 ```
 sudo -Hiu postgres pgbackrest restore --stanza=main --db-path=/var/lib/pgsql/11/br_restore
 ```{{execute T1}}
-If this is done, it is critically important to ***TURN OFF THE ARCHIVE COMMAND***. Otherwise, if your target destination also has write access to the pgbackrest repository, you will have two locations writing there and likely corrupt the entire backup. As stated earlier, the easiest way to disable the archive_command on a linux system is to set it to `/bin/true`.
+If this is done, it is critically important to ***TURN OFF THE ARCHIVE COMMAND***. Otherwise, if your target destination also has write access to the pgBackRest repository, you will have two locations writing there and likely corrupt the entire repository. As stated earlier, the easiest way to disable the archive_command on a linux system is to set it to `/bin/true`.
 
-The Restore section of the pgbackrest userguide has much more thorough explanations of these restore situations - https://pgbackrest.org/user-guide-centos7.html#restore
+The Restore section of the pgBackRest user guide has much more thorough explanations of these restore situations - https://pgbackrest.org/user-guide-centos7.html#restore

--- a/pg-administration/basic-postgresql-for-dbas/pgbackrest/index.json
+++ b/pg-administration/basic-postgresql-for-dbas/pgbackrest/index.json
@@ -1,11 +1,11 @@
   {
-  "title": "PGBackRest",
-  "description": "PGBackRest",
+  "title": "pgBackRest",
+  "description": "pgBackRest",
   "difficulty": "beginner",
   "time": "20 minutes",
   "details": {
     "steps": [
-      {"title": "Setting up PostgreSQL to use PGBackRest", "text": "10-pg-setup.md"},
+      {"title": "Setting up PostgreSQL to use pgBackRest", "text": "10-pg-setup.md"},
       {"title": "Setting up PGBackrest", "text": "20-backrest-setup.md"},
       {"title": "Running Backups", "text": "30-running-backup.md"},
       {"title": "Restoring with PGBackrest", "text": "40-backrest-restore.md"}

--- a/pg-administration/basic-postgresql-for-dbas/pgbackrest/intro.md
+++ b/pg-administration/basic-postgresql-for-dbas/pgbackrest/intro.md
@@ -1,6 +1,6 @@
-# PGBackRest
-This scenario will go over the basics of using pgbackrest to perform backups and restoration. It has many, many more options available within it for customizing your backup processes, but this scenario should help you get started with it.
- 
+# pgBackRest
+This scenario will go over the basics of using pgBackRest to perform backups and restoration. It has many, many more options available within it for customizing your backup processes, but this scenario should help you get started with it.
+
 Full documentation is available at https://pgbackrest.org/
 
 Let's get started!


### PR DESCRIPTION
The main change is to consistently use pgBackRest when referring to the project rather than pgbackrest, PGBackRest, backrest, and pgBaseBackup.  This reduces confusion for the user and search engines.  pgbackrest should only be used when invoking the binary or specifically taking about the binary.

Also did a light edit for spelling and grammar.

My code editor automatically removes multiple final linefeeds so there is a bit of noise from that.  However, I think it would be better to remove them anyway.

I have not tested these changes on Katacoda so that should be done before committing.