### PR TITLE
Initial Attempt at Postgres Operator Modules

### DIFF
--- a/postgres-operator/pgo-for-operator-admins/env-init.sh
+++ b/postgres-operator/pgo-for-operator-admins/env-init.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+# Runs in the background

--- a/postgres-operator/pgo-for-operator-admins/finish.md
+++ b/postgres-operator/pgo-for-operator-admins/finish.md
@@ -1,0 +1,1 @@
+# Complete

--- a/postgres-operator/pgo-for-operator-admins/index.json
+++ b/postgres-operator/pgo-for-operator-admins/index.json
@@ -1,0 +1,33 @@
+ {
+  "title": "PostgreSQL Operator for Kubernetes for Admins",
+  "description": "Introduction to PostgreSQL Operator for Kubernetes Admins",
+  "difficulty": "beginniner",
+  "time": "10 minutes",
+  "details": {
+    "steps": [
+      {"title": "pgo-for-operator-admins", "text": "pgo-for-operator-admins.md"}
+    ],
+    "intro": {
+      "courseData": "env-init.sh",
+      "code": "set-env.sh",
+      "text": "intro.md",
+      "credits": ""
+    },
+    "finish": {
+      "text": "finish.md"
+    },
+    "assets": {
+      "client": []
+    }
+  },
+  "environment": {
+    "uilayout": "terminal",
+    "uimessage1": "\u001b[32mYour Interactive Bash Terminal\u001b[m\r\n",
+    "terminals": [
+      {"name": "Terminal 2", "target": "host01"}
+    ]
+  },
+  "backend": {
+    "imageid": "crunchydata-k8s-centos"
+  }
+}

--- a/postgres-operator/pgo-for-operator-admins/intro.md
+++ b/postgres-operator/pgo-for-operator-admins/intro.md
@@ -1,0 +1,14 @@
+## PostgreSQL Operator for Admins
+
+This scenario is going to give you an introduction to PostgreSQL Operator administration within a Kubernetes environment - focused on the administration of the PostgreSQL Operator itself, rather than the creation or administration of PostgreSQL instances or clusters within Kubernetes by using the PostgreSQL Operator. 
+
+With the PostgreSQL Operator for Kubernetes installed in your Kubernetes environment, PostgreSQL Operator admins have the ability to perform a number of administrative actions related to the maintainance of the PostgreSQL Operator, as well as to perform troubleshooting of the PostgreSQL Operator if necessary. . 
+
+The PostgreSQL Operator provides a command line tool, ```pgo```, that is used to interact with the PostgreSQL Operator and will be the basis of this scenario.  While the full `pgo` client reference will tell you everything you need to know about how to use `pgo`, it may be helpful to see several examples on how to conduct "day-in-the-life" tasks for administrating 
+the PostgreSQL Operator.
+
+This scenario will work through the commands associated with:
+
+* [to come]
+
+The PostgreSQL Operator by Crunchy Data extends Kubernetes to give users the ability to easily  create, configure and manage PostgreSQL clusters at scale.  When combined with the Crunchy Data's PostgreSQL Containers, the PostgreSQL Operator provides an open source software solution for PostgreSQL scaling, high-availability, disaster recovery, monitoring, and more.  All of this capability comes with the repeatability and automation that comes from Operators on Kubernetes.

--- a/postgres-operator/pgo-for-operator-admins/pgo-commands-for-admins.md
+++ b/postgres-operator/pgo-for-operator-admins/pgo-commands-for-admins.md
@@ -1,0 +1,238 @@
+## Setup Before Running the Examples
+
+Many of the `pgo` client commands require you to specify a namespace via the
+`-n` or `--namespace` flag. 
+
+If you install the PostgreSQL Operator using the quickstart
+guide, you will have two namespaces installed: `pgouser1` and `pgouser2`. We
+can choose to always use one of these namespaces by setting the `PGO_NAMESPACE`
+environmental variable, which is detailed in the global pgo Client
+reference. 
+
+For convenience, we will use the `pgouser1` namespace in the examples below.
+For even more convenience, we recommend setting `pgouser1` to be the value of
+the `PGO_NAMESPACE` variable. 
+
+In the shell that you will be executing the `pgo`commands in, run the following command:
+
+```shell
+export PGO_NAMESPACE=pgouser1
+```
+
+If you do not wish to set this environmental variable, or are in an environment
+where you are unable to use environmental variables, you will have to use the
+`--namespace` (or `-n`) flag for most commands, e.g.
+
+`pgo version -n pgouser1`
+
+### JSON Output
+
+The default for the `pgo` client commands is to output their results in a
+readable format. However, there are times where it may be helpful to you to have
+the format output in a machine parseable format like JSON.
+
+Several commands support the `-o`/`--output` flags that delivers the results of
+the command in the specified output. Presently, the only output that is
+supported is `json`.
+
+As an example of using this feature, if you wanted to get the results of the
+`pgo test` command in JSON, you could run the following:
+
+```shell
+pgo test hacluster -o json
+
+### Checking Connectivity to the PostgreSQL Operator
+
+A common administrative task when working with the PostgreSQL Operator is to check connectivity
+to the PostgreSQL Operator. This can be accomplish with the ```pgo version``` command:
+
+```shell
+pgo version
+```
+
+which, if working, will yield results similar to:
+
+```
+pgo client version 4.3.0
+pgo-apiserver version 4.3.0
+```
+
+### Inspecting the PostgreSQL Operator Configuration
+
+The ```pgo show config``` command allows you to view the current configuration that 
+the PostgreSQL Operator is using. This can be helpful for troubleshooting issues such 
+as which PostgreSQL images are being deployed by default, which storage classes are 
+being used, etc.
+
+You can run the ```pgo show config``` command by running:
+
+```shell
+pgo show config
+```
+
+which yields output similar to:
+
+BasicAuth: ""
+Cluster:
+  CCPImagePrefix: crunchydata
+  CCPImageTag: centos7-12.2-4.3.0
+  PrimaryNodeLabel: ""
+  ReplicaNodeLabel: ""
+  Policies: ""
+  Metrics: false
+  Badger: false
+  Port: "5432"
+  PGBadgerPort: "10000"
+  ExporterPort: "9187"
+  User: testuser
+  Database: userdb
+  PasswordAgeDays: "60"
+  PasswordLength: "8"
+  Strategy: "1"
+  Replicas: "0"
+  ServiceType: ClusterIP
+  BackrestPort: 2022
+  Backrest: true
+  BackrestS3Bucket: ""
+  BackrestS3Endpoint: ""
+  BackrestS3Region: ""
+  DisableAutofail: false
+  PgmonitorPassword: ""
+  EnableCrunchyadm: false
+  DisableReplicaStartFailReinit: false
+  PodAntiAffinity: preferred
+  SyncReplication: false
+Pgo:
+  PreferredFailoverNode: ""
+  Audit: false
+  PGOImagePrefix: crunchydata
+  PGOImageTag: centos7-4.3.0
+ContainerResources:
+  large:
+    RequestsMemory: 2Gi
+    RequestsCPU: "2.0"
+    LimitsMemory: 2Gi
+    LimitsCPU: "4.0"
+  small:
+    RequestsMemory: 256Mi
+    RequestsCPU: "0.1"
+    LimitsMemory: 256Mi
+    LimitsCPU: "0.1"
+PrimaryStorage: nfsstorage
+BackupStorage: nfsstorage
+ReplicaStorage: nfsstorage
+BackrestStorage: nfsstorage
+Storage:
+  nfsstorage:
+    AccessMode: ReadWriteMany
+    Size: 1G
+    StorageType: create
+    StorageClass: ""
+    Fsgroup: ""
+    SupplementalGroups: "65534"
+    MatchLabels: ""
+DefaultContainerResources: ""
+DefaultLoadResources: ""
+DefaultRmdataResources: ""
+DefaultBackupResources: ""
+DefaultBadgerResources: ""
+DefaultPgbouncerResources: ""
+
+### Viewing PostgreSQL Operator Key Metrics
+
+The ```pgo status``` command provides a generalized statistical view of 
+the overall resource consumption of the PostgreSQL Operator. These stats include:
+
+- The total number of PostgreSQL instances
+- The total number of Persistent Volume Claims (PVC) that are allocated, along with the total amount of disk the claims specify
+- The types of container images that are deployed, along with how many are deployed
+- The nodes that are used by the PostgreSQL Operator
+
+and more
+
+You can use the ```pgo status``` command by running:
+
+```shell
+pgo status
+```
+
+which yields output similar to:
+
+
+Operator Start:          2019-12-26 17:53:45 +0000 UTC
+Databases:               8
+Claims:                  8
+Total Volume Size:       8Gi       
+
+Database Images:
+                         4	crunchydata/crunchy-postgres-ha:centos7-12.2-4.3.0
+                         4	crunchydata/pgo-backrest-repo:centos7-4.3.0
+                         8	crunchydata/pgo-backrest:centos7-4.3.0
+
+Databases Not Ready:
+
+Nodes:
+	master                        
+		Status:Ready                         
+		Labels:
+			beta.kubernetes.io/arch=amd64
+			beta.kubernetes.io/os=linux
+			kubernetes.io/arch=amd64
+			kubernetes.io/hostname=master
+			kubernetes.io/os=linux
+			node-role.kubernetes.io/master=
+	node01                        
+		Status:Ready                         
+		Labels:
+			beta.kubernetes.io/arch=amd64
+			beta.kubernetes.io/os=linux
+			kubernetes.io/arch=amd64
+			kubernetes.io/hostname=node01
+			kubernetes.io/os=linux
+
+Labels (count > 1): [count] [label]
+	[8]	[vendor=crunchydata]
+	[4]	[pgo-backrest-repo=true]
+	[4]	[pgouser=pgoadmin]
+	[4]	[pgo-pg-database=true]
+	[4]	[crunchy_collect=false]
+	[4]	[pg-pod-anti-affinity=]
+	[4]	[pgo-version=4.3.0]
+	[4]	[archive-timeout=60]
+	[2]	[pg-cluster=hacluster]
+
+
+### Viewing PostgreSQL Operator Managed Namespaces
+
+The PostgreSQL Operator has the ability to manage PostgreSQL clusters across
+Kubernetes Namespaces. During the course of PostgreSQL Operator operations, 
+it can be helpful to know which namespaces the PostgreSQL Operator can use 
+for deploying PostgreSQL clusters.
+
+You can view which namespaces the PostgreSQL Operator can utilize by using
+the ```pgo show namespace``` command. To list out the namespaces that the PostgreSQL 
+Operator has access to, you can run the following command:
+
+```shell
+pgo show namespace --all
+```
+
+which yields output similar to:
+
+pgo username: pgoadmin
+namespace                useraccess          installaccess       
+default                  accessible          no access           
+kube-node-lease          accessible          no access           
+kube-public              accessible          no access           
+kube-system              accessible          no access           
+pgo                      accessible          no access           
+pgouser1                 accessible          accessible          
+pgouser2                 accessible          accessible          
+somethingelse            no access           no access   
+
+
+Based on your deployment, your Kubernetes administrator may restrict
+access to the multi-namespace feature of the PostgreSQL Operator. In this case,
+you do not need to worry about managing your namespaces and as such do not need
+to use this command, but we recommend setting the `PGO_NAMESPACE` variable as
+described in the PostgreSQL Operator documentation. 

--- a/postgres-operator/pgo-for-operator-admins/set-env.sh
+++ b/postgres-operator/pgo-for-operator-admins/set-env.sh
@@ -1,0 +1,3 @@
+#!bash
+
+TO COME

--- a/postgres-operator/pgo-for-postgres-users/env-init.sh
+++ b/postgres-operator/pgo-for-postgres-users/env-init.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+# Runs in the background

--- a/postgres-operator/pgo-for-postgres-users/finish.md
+++ b/postgres-operator/pgo-for-postgres-users/finish.md
@@ -1,0 +1,1 @@
+# Complete

--- a/postgres-operator/pgo-for-postgres-users/index.json
+++ b/postgres-operator/pgo-for-postgres-users/index.json
@@ -1,0 +1,33 @@
+ {
+  "title": "Basic PostgreSQL Provisioning on Kubernetes",
+  "description": "Introduction to PostgreSQL Cluster Operations on PostgreSQL Operator for Kubernetes",
+  "difficulty": "beginniner",
+  "time": "10 minutes",
+  "details": {
+    "steps": [
+      {"title": "postgres-operator", "text": "cluster-creation.md"}
+    ],
+    "intro": {
+      "courseData": "env-init.sh",
+      "code": "set-env.sh",
+      "text": "intro.md",
+      "credits": ""
+    },
+    "finish": {
+      "text": "finish.md"
+    },
+    "assets": {
+      "client": []
+    }
+  },
+  "environment": {
+    "uilayout": "terminal",
+    "uimessage1": "\u001b[32mYour Interactive Bash Terminal\u001b[m\r\n",
+    "terminals": [
+      {"name": "Terminal 2", "target": "host01"}
+    ]
+  },
+  "backend": {
+    "imageid": "crunchydata-k8s-centos"
+  }
+}

--- a/postgres-operator/pgo-for-postgres-users/intro.md
+++ b/postgres-operator/pgo-for-postgres-users/intro.md
@@ -1,0 +1,25 @@
+# PostgreSQL Cluster Operation with PostgreSQL Operator for Kubernetes
+
+This scenario is going to give you an introduction to PostgreSQL cluster creation and operation using the PostgreSQL Operator for Kubernetes. 
+
+With the PostgreSQL Operator for Kubernetes installed in your Kubernetes environment, application developers have the ability easily provision and manage PostgreSQL clusters using a set of simple commands. The goal of this class is to introduce you to the PostgreSQL Operator for Kubernetes capability and get your started with some basic PostgreSQL cluster operations. 
+
+The PostgreSQL Operator provides a command line tool, ```pgo```, that is used to interact with the PostgreSQL Operator and will be the basis of this scenario. 
+
+This scenario will work through the commands associated with:
+
+* creating a single instance PostgreSQL cluster 
+
+* adding a PostgreSQL replica to your PostgreSQL cluster 
+
+* viewing the PostgreSQL logs
+
+* create a PostgreSQL backup job using pgbackrest 
+
+* remove a PostgreSQL replica using the following:
+
+* delete the PostgreSQL cluster and its associated persistent volume claims
+
+The PostgreSQL Operator by Crunchy Data extends Kubernetes to give users the ability to easily  create, configure and manage PostgreSQL clusters at scale.  When combined with the Crunchy Data's PostgreSQL Containers, the PostgreSQL Operator provides an open source software solution for PostgreSQL scaling, high-availability, disaster recovery, monitoring, and more.  All of this capability comes with the repeatability and automation that comes from Operators on Kubernetes.
+ 
+

--- a/postgres-operator/pgo-for-postgres-users/pgo-commands-quickstart.md
+++ b/postgres-operator/pgo-for-postgres-users/pgo-commands-quickstart.md
@@ -1,0 +1,48 @@
+# PostgreSQL Operator Commands Quickstart for PostgreSQL Users
+
+In this example, we will assume that the PostgreSQL Operator has been installed and configured in your Kubernetes environment, and focus on working through a few of the common ```pgo``` commands that would be used by a typical PostgreSQL user in a Kubernetes environment.  work through the creation of a PostgreSQL cluster using the PostgreSQL Operator, as well as perform a few common PostgreSQL cluster operations. 
+
+Throughout this example, the pgo commands are specifying the pgouser1 namespace as the target of the PostgreSQL Operator. 
+
+Replace this value with your own namespace value. You can specify a default namespace to be used by setting the PGO_NAMESPACE environment variable on the pgo client environment.
+
+To begin, we will use the PostgreSQL Operator to create a single instance PostgreSQL cluster using the following ```pgo``` command:
+
+```pgo create cluster mycluster -n pgouser1```
+
+This command creates a PostgreSQL cluster in the pgouser1 namespace that has a single PostgreSQL primary container.
+
+You can see the PostgreSQL cluster running in your environment using the following ```pgo``` command: 
+
+```pgo show cluster mycluster -n pgouser1```
+
+You can test the PostgreSQL cluster by using the following ```pgo``` command: 
+
+```pgo test mycluster -n pgouser1```
+
+With the PostgreSQL instance up and running, you can now add a PostgreSQL replica instance to your PostgreSQL cluster. As a reminder, PostgreSQL has a single primary / multiple read replica architecture. 
+
+To add a PostgreSQL replica to your PostgreSQL cluster, use the following ```pgo``` command:
+
+```pgo scale mycluster -n pgouser1```
+
+By default the PostgreSQL Operator deploys pgbackrest for a PostgreSQL cluster to hold database backup data.  pgbackrest is an open source, high performance, backup and restore utility for PostgreSQL. 
+
+To create a pgbackrest backup job, use the following ```pgo``` command:
+
+```pgo backup mycluster -n pgouser1```
+
+You can show the current backups on a PostgreSQL cluster with the following ```pgo``` command:
+
+```pgo show backup mycluster -n pgouser1```
+
+To the extent you determined that you no longer need your read replica PostgreSQL instance, you can remove the PostgreSQL replica instance using the following ```pgo``` command:
+
+```pgo scaledown mycluster --query -n pgouser1```
+```pgo scaledown mycluster --target=sometarget -n pgouser1```
+
+To delete the full PostgreSQL cluster and the associated persistent volume claims, you can use the following ```pgo``` command:
+
+```pgo delete cluster mycluster --delete-data -n pgouser1```
+
+With that sequence of simple commands, you have spun up a PostgreSQL cluster, scaled it up with a read replica, created a backup, scaled the cluster down and ultimately deleted your cluster. 

--- a/postgres-operator/pgo-for-postgres-users/set-env.sh
+++ b/postgres-operator/pgo-for-postgres-users/set-env.sh
@@ -1,0 +1,3 @@
+#!bash
+
+TO COME


### PR DESCRIPTION
Initial attempt at creating two Postgres Operator modules, roughly:

-- PostgreSQL Operator for Admins (i.e., commands for folks who are administering the Operator)

-- PostgreSQL Operator for PostgreSQL Users (i.e., commands for folks who are Operator users)

This will of course need some work to improve the content and polish, but hopefully a reasonable initial framework for two common user types and gets u started towards these initial two modules. 

A few notes:

1. the commands for the "PostgreSQL Users" module are pre-4.2 and likely out of date, this will need to be updated (can submit as a follow up PR if folks are onboard with this organization / structure)

2. havent attempted set-env.sh in either modules, I am going to need some help there


