### PR TITLE
Fix native partitioning & logical replication scenarios for new base image

### DIFF
--- a/pg-administration/basic-postgresql-for-dbas-11/pgbasebackup/10-running-backup.md
+++ b/pg-administration/basic-postgresql-for-dbas-11/pgbasebackup/10-running-backup.md
@@ -1,6 +1,6 @@
 The pg_dump/restore commands are useful for getting logical dumps of the database schema and its data out. But for large databass, dumps are not very practical for typical backup requirements. Especially from the point of a full database recovery since all indexes and constraints have to be rebuilt, taking quite a long time.
 
-The `pg_basebackup` command can provide a complete, filesystem-based snapshot of the entire database cluster. It was already used in in the earlier `Replication` scenario of this training session to create the replica. It can also be used in a very similar manner to provide a compressed backup. And while pg_dump could be configured to only dump specific objects, `pg_basebackup` is always a complete copy of the entire database as of the time that the backup stops running.
+The `pg_basebackup` command can provide a complete, filesystem-based snapshot of the entire database cluster. It was already used in the earlier `Replication` scenario of this training session to create the replica. It can also be used in a very similar manner to provide a compressed backup. And while pg_dump could be configured to only dump specific objects, `pg_basebackup` is always a complete copy of the entire database as of the time that the backup stops running.
 
 https://www.postgresql.org/docs/current/app-pgbasebackup.html
 

--- a/pg-administration/basic-postgresql-for-dbas-12/pgbasebackup/10-running-backup.md
+++ b/pg-administration/basic-postgresql-for-dbas-12/pgbasebackup/10-running-backup.md
@@ -1,6 +1,6 @@
 The pg_dump/restore commands are useful for getting logical dumps of the database schema and its data out. But for large databass, dumps are not very practical for typical backup requirements. Especially from the point of a full database recovery since all indexes and constraints have to be rebuilt, taking quite a long time.
 
-The `pg_basebackup` command can provide a complete, filesystem-based snapshot of the entire database cluster. It was already used in in the earlier `Replication` scenario of this training session to create the replica. It can also be used in a very similar manner to provide a compressed backup. And while pg_dump could be configured to only dump specific objects, `pg_basebackup` is always a complete copy of the entire database as of the time that the backup stops running.
+The `pg_basebackup` command can provide a complete, filesystem-based snapshot of the entire database cluster. It was already used in the earlier `Replication` scenario of this training session to create the replica. It can also be used in a very similar manner to provide a compressed backup. And while pg_dump could be configured to only dump specific objects, `pg_basebackup` is always a complete copy of the entire database as of the time that the backup stops running.
 
 https://www.postgresql.org/docs/current/app-pgbasebackup.html
 

--- a/pg-administration/postgresql-features/logical-replication/10-setup.md
+++ b/pg-administration/postgresql-features/logical-replication/10-setup.md
@@ -7,14 +7,14 @@ psql -c "SHOW max_wal_senders"
 ```{{execute T1}}
 Note that all settings mentioned above require a restart to put into affect when changed
 ```
-systemctl restart postgresql-12
+sudo systemctl restart postgresql-12
 ```{{execute T1}}
 Just like with standard replication, a role with the REPLICATION property must exist for the subscribers to connect with. The `replica_user` role has already been created on the demo database along with the proper pg_hba.conf entry to allow secure password authentication. Note that unlike regular replication, you must set it to allow the replica_user to connect to the database that contains the publisher, not the special `replication` database.
 ```
 psql -c "\du" 
 ```{{execute T1}}
 ```
-cat /var/lib/pgsql/12/data/pg_hba.conf
+sudo cat /var/lib/pgsql/12/data/pg_hba.conf
 ```{{execute T1}}
 
 

--- a/pg-administration/postgresql-features/logical-replication/10-setup.md
+++ b/pg-administration/postgresql-features/logical-replication/10-setup.md
@@ -7,14 +7,14 @@ psql -c "SHOW max_wal_senders"
 ```{{execute T1}}
 Note that all settings mentioned above require a restart to put into affect when changed
 ```
-systemctl restart postgresql-11
+systemctl restart postgresql-12
 ```{{execute T1}}
 Just like with standard replication, a role with the REPLICATION property must exist for the subscribers to connect with. The `replica_user` role has already been created on the demo database along with the proper pg_hba.conf entry to allow secure password authentication. Note that unlike regular replication, you must set it to allow the replica_user to connect to the database that contains the publisher, not the special `replication` database.
 ```
 psql -c "\du" 
 ```{{execute T1}}
 ```
-cat /var/lib/pgsql/11/data/pg_hba.conf
+cat /var/lib/pgsql/12/data/pg_hba.conf
 ```{{execute T1}}
 
 

--- a/pg-administration/postgresql-features/logical-replication/30-subscription.md
+++ b/pg-administration/postgresql-features/logical-replication/30-subscription.md
@@ -12,6 +12,8 @@ As stated before, schema changes are not replicated, so the tables receiving sub
 
 Our setup is rather simple, so just recreating the tables manually is easy. For larger setups, it's more useful to use the `--schema-only` option to `pg_dump` to dump out the structure of the desired objects and restore them to the subscriber.
 ```
+sudo -iu training
+
 psql -p 5444
 
 CREATE TABLE user_login  (user_id bigint PRIMARY KEY, username text, last_login timestamptz DEFAULT now());
@@ -19,9 +21,9 @@ CREATE TABLE user_login  (user_id bigint PRIMARY KEY, username text, last_login 
 CREATE TABLE forum_posts  (post_id bigint PRIMARY KEY, post text, post_time timestamptz DEFAULT now(), update_time timestamptz DEFAULT now());
 ```{{execute T2}}
 ```
-CREATE SUBSCRIPTION forum_post_sub CONNECTION 'dbname=root host=127.0.0.1 user=replica_user password=12345' PUBLICATION forum_posts_pub;
+CREATE SUBSCRIPTION forum_post_sub CONNECTION 'dbname=training host=127.0.0.1 user=replica_user password=12345' PUBLICATION forum_posts_pub;
 
-CREATE SUBSCRIPTION user_login_sub CONNECTION 'dbname=root host=127.0.0.1 user=replica_user password=12345' PUBLICATION forum_users_pub;
+CREATE SUBSCRIPTION user_login_sub CONNECTION 'dbname=training host=127.0.0.1 user=replica_user password=12345' PUBLICATION forum_users_pub;
 ```{{execute T2}}
 This creates replication slots for this subscription back on the publisher database...
 ```

--- a/pg-administration/postgresql-features/logical-replication/env-init.sh
+++ b/pg-administration/postgresql-features/logical-replication/env-init.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/bash
+
+# Runs in the background
+
+adduser training
+echo "training" | passwd training --stdin
+usermod -aG wheel training
+echo "training ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+cat > pg_hba.conf << EOF
+# TYPE  DATABASE       USER           ADDRESS         METHOD
+host    training        replica_user    127.0.0.1/32   scram-sha-256
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+EOF
+
+/usr/bin/cp /var/lib/pgsql/12/data/pg_hba.conf /var/lib/pgsql/12/data/pg_hba.conf.orig
+chown postgres:postgres /var/lib/pgsql/12/data/pg_hba.conf.orig
+/usr/bin/cp -f pg_hba.conf /var/lib/pgsql/12/data/pg_hba.conf  
+
+systemctl enable postgresql-12
+systemctl start postgresql-12
+
+sudo -Hiu postgres psql -U postgres -c "ALTER SYSTEM SET password_encryption = 'scram-sha-256'"
+sudo systemctl restart postgresql-12
+sudo -Hiu postgres psql -U postgres -c "CREATE ROLE training WITH LOGIN SUPERUSER"
+sudo -Hiu postgres psql -U postgres -c "CREATE ROLE replica_user WITH LOGIN REPLICATION PASSWORD '12345'"
+
+sudo -u postgres psql -U postgres -c "CREATE DATABASE training"
+sudo -u postgres psql -U postgres -c "ALTER DATABASE training OWNER TO training"
+
+sudo -Hiu postgres mkdir /var/lib/pgsql/12/subdb
+sudo -Hiu postgres chmod 700 /var/lib/pgsql/12/subdb
+sudo -Hiu postgres /usr/pgsql-12/bin/initdb -D /var/lib/pgsql/12/subdb -k 
+sed -i "/port = 5432/c\port = 5444" /var/lib/pgsql/12/subdb/postgresql.conf
+sudo -Hiu postgres /usr/pgsql-12/bin/pg_ctl -D /var/lib/pgsql/12/subdb start
+
+sudo -Hiu postgres psql -U postgres -p 5444 -c "CREATE ROLE training WITH LOGIN SUPERUSER"
+sudo -Hiu postgres psql -U postgres -p 5444 -c "CREATE DATABASE training"
+
+systemctl restart postgresql-12

--- a/pg-administration/postgresql-features/logical-replication/index.json
+++ b/pg-administration/postgresql-features/logical-replication/index.json
@@ -10,6 +10,7 @@
       {"title": "Subscription", "text": "30-subscription.md"}
     ],
     "intro": {
+      "courseData": "env-init.sh",
       "code": "set-env.sh",
       "text": "intro.md",
       "credits": ""

--- a/pg-administration/postgresql-features/logical-replication/set-env.sh
+++ b/pg-administration/postgresql-features/logical-replication/set-env.sh
@@ -2,40 +2,13 @@
 
 #runs in foreground
 
-adduser training
-echo "training" | passwd training --stdin
+CURRENT_USER=$(whoami)
 
-cat > /var/lib/pgsql/11/data/pg_hba.conf << EOF
-# TYPE  DATABASE       USER           ADDRESS         METHOD
-host    root        replica_user    127.0.0.1/32   scram-sha-256
-
-# "local" is for Unix domain socket connections only
-local   all             all                                     peer
-# IPv4 local connections:
-host    all             all             127.0.0.1/32            ident
-# IPv6 local connections:
-host    all             all             ::1/128                 ident
-EOF
-
-sudo systemctl enable postgresql-11
-sudo systemctl start postgresql-11
-
-sudo -Hiu postgres psql -U postgres -c "ALTER SYSTEM SET password_encryption = 'scram-sha-256'"
-sudo systemctl restart postgresql-11
-sudo -Hiu postgres psql -U postgres -c "CREATE ROLE root WITH LOGIN SUPERUSER"
-sudo -Hiu postgres psql -U postgres -c "CREATE ROLE replica_user WITH LOGIN REPLICATION PASSWORD '12345'"
-
-sudo -Hiu postgres psql -U postgres -c "CREATE DATABASE root"
-
-sudo -Hiu postgres mkdir /var/lib/pgsql/11/subdb
-sudo -Hiu postgres chmod 700 /var/lib/pgsql/11/subdb
-sudo -Hiu postgres /usr/pgsql-11/bin/initdb -D /var/lib/pgsql/11/subdb -k 
-sed -i "/port = 5432/c\port = 5444" /var/lib/pgsql/11/subdb/postgresql.conf
-sudo -Hiu postgres /usr/pgsql-11/bin/pg_ctl -D /var/lib/pgsql/11/subdb start
-
-sudo -Hiu postgres psql -U postgres -p 5444 -c "CREATE ROLE root WITH LOGIN SUPERUSER"
-sudo -Hiu postgres psql -U postgres -p 5444 -c "CREATE DATABASE root"
-
-
+until [ $CURRENT_USER == "training" ]; do
+    sudo -iu training
+    CURRENT_USER=$(whoami)
+    echo >&2 "$(date +%Y%m%dt%H%M%S) Waiting for current user to change to training..."
+    sleep 1;
+done
 
 clear

--- a/pg-administration/postgresql-features/native-partitioning/10-range.md
+++ b/pg-administration/postgresql-features/native-partitioning/10-range.md
@@ -2,7 +2,7 @@ PostgreSQL supports several types of native partitioning: Range, List, & Hash.
 
 Range partitioning works by splitting the data on 1 or more columns based on a blocks of data with bound limits, typically time or integer series.
 
-Log into postgres using the psql client. A `root` role and database has already been created to allow easy login.
+Log into postgres using the psql client. A `training` role and database has already been created to allow easy login.
 ```
 psql
 ```{{execute T1}}

--- a/pg-administration/postgresql-features/native-partitioning/env-init.sh
+++ b/pg-administration/postgresql-features/native-partitioning/env-init.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/bash
+
+# Runs in the background
+
+adduser training
+echo "training" | passwd training --stdin
+usermod -aG wheel training
+echo "training ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+cat > pg_hba.conf << EOF
+# TYPE  DATABASE       USER           ADDRESS         METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+EOF
+
+/usr/bin/cp /var/lib/pgsql/12/data/pg_hba.conf /var/lib/pgsql/12/data/pg_hba.conf.orig
+chown postgres:postgres /var/lib/pgsql/12/data/pg_hba.conf.orig
+/usr/bin/cp -f pg_hba.conf /var/lib/pgsql/12/data/pg_hba.conf  
+
+systemctl enable postgresql-12
+systemctl start postgresql-12
+
+sudo -u postgres psql -U postgres -c "CREATE ROLE training WITH LOGIN SUPERUSER"
+
+sudo -u postgres psql -U postgres -c "CREATE DATABASE training"
+sudo -u postgres psql -U postgres -c "ALTER DATABASE training OWNER TO training"
+
+systemctl restart postgresql-12

--- a/pg-administration/postgresql-features/native-partitioning/index.json
+++ b/pg-administration/postgresql-features/native-partitioning/index.json
@@ -13,6 +13,7 @@
       {"title": "Partition Management", "text": "60-partman.md"}
     ],
     "intro": {
+      "courseData": "env-init.sh",
       "code": "set-env.sh",
       "text": "intro.md",
       "credits": ""

--- a/pg-administration/postgresql-features/native-partitioning/set-env.sh
+++ b/pg-administration/postgresql-features/native-partitioning/set-env.sh
@@ -2,14 +2,13 @@
 
 #runs in foreground
 
-adduser training
-echo "training" | passwd training --stdin
+CURRENT_USER=$(whoami)
 
-sudo systemctl enable postgresql-11
-sudo systemctl start postgresql-11
-
-sudo -u postgres psql -U postgres -c "CREATE ROLE root WITH LOGIN SUPERUSER"
-
-sudo -u postgres psql -U postgres -c "CREATE DATABASE root"
+until [ $CURRENT_USER == "training" ]; do
+    sudo -iu training
+    CURRENT_USER=$(whoami)
+    echo >&2 "$(date +%Y%m%dt%H%M%S) Waiting for current user to change to training..."
+    sleep 1;
+done
 
 clear


### PR DESCRIPTION
Updated the environment setup for the native partitioning & logical replication scenarios to use the new environment setup method that the administration scenarios use.

Also update them to use PG12