### PR TITLE
Move k8s to generic K8s CentOS base Images

### DIFF
--- a/environments/crunchydata-k8s-centos/katacoda.yaml
+++ b/environments/crunchydata-k8s-centos/katacoda.yaml
@@ -1,0 +1,1 @@
+base: 'kubernetes-cluster-centos7:1-16'

--- a/environments/crunchydata-k8s-centos/master/build/1_k8s_master.sh
+++ b/environments/crunchydata-k8s-centos/master/build/1_k8s_master.sh
@@ -1,53 +1,6 @@
 set -e
-sudo rpm --import https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
-sudo yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-if [ "$?" -ne 0 ]; then
-    echo "Unable to install Postgres Repo"
-    exit 1
-fi
-sudo yum remove -y docker docker-common
 
-sudo yum install -y yum-utils
-
-sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum install -y docker-ce docker-ce-cli containerd.io unzip nano postgresql12
-systemctl enable --now docker
-systemctl start docker
-
-echo '127.0.0.1 master' >> /etc/hosts
-hostname master && echo master > /etc/hostname
-hostnamectl set-hostname master
-
-cat <<EOF > /etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-exclude=kube*
-EOF
-
-# Set SELinux in permissive mode (effectively disabling it)
-setenforce 0
-sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
-
-yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
-
-systemctl enable --now kubelet
-
-cat <<EOF >  /etc/sysctl.d/k8s.conf
-net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-EOF
-sysctl --system
-
-sudo kubectl completion bash | sudo tee -a /etc/bash_completion.d/kubectl
-echo Pulling Images; 
-sudo kubeadm config images pull; 
-sudo docker pull weaveworks/weave-kube:2.5.1
-sudo docker pull weaveworks/weave-npc:2.5.1
+sudo yum install -y postgresql12
 
 # Operator Work Now - we should go all the way through and actually put the operator into the cluster
 # This means we will need to spin up the cluster install and then shut it down cleanly
@@ -91,6 +44,4 @@ sudo docker pull crunchydata/pgo-sqlrunner:centos7-4.2.2
 sudo docker pull crunchydata/crunchy-admin:centos7-12.2-4.2.2
 sudo docker pull crunchydata/crunchy-postgres-ha:centos7-12.2-4.2.2
 sudo docker pull crunchydata/crunchy-postgres-gis-ha:centos7-12.2-4.2.2
-
-
 

--- a/environments/crunchydata-k8s-centos/master/build/1_k8s_master.sh
+++ b/environments/crunchydata-k8s-centos/master/build/1_k8s_master.sh
@@ -1,4 +1,10 @@
 set -e
+sudo rpm --import https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+sudo yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+if [ "$?" -ne 0 ]; then
+    echo "Unable to install Postgres Repo"
+    exit 1
+fi
 
 sudo yum install -y postgresql12
 

--- a/environments/crunchydata-k8s-centos/master/build/2_scripts.sh
+++ b/environments/crunchydata-k8s-centos/master/build/2_scripts.sh
@@ -1,3 +1,5 @@
+sudo docker pull storageos/node:1.5.0
+
 cat <<EOFPARENT > /opt/create-pv.sh
 kubectl create -f https://github.com/storageos/cluster-operator/releases/download/1.5.0/storageos-operator.yaml
 
@@ -47,14 +49,14 @@ chmod +x /opt/create-pv.sh
 
 cat <<EOF > /opt/launch-kubeadm.sh
 #!/bin/sh
-rm $HOME/.kube/config
+rm \$HOME/.kube/config
 kubeadm reset -f || true
 systemctl start kubelet
 mkdir -p /root/.kube
-kubeadm init --kubernetes-version $(kubeadm version -o short) --token=96771a.f608976060d16396
-mkdir -p $HOME/.kube
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
-sudo chown $(id -u):$(id -g) $HOME/.kube/config
+kubeadm init --kubernetes-version \$(kubeadm version -o short) --token=96771a.f608976060d16396
+mkdir -p \$HOME/.kube
+sudo cp -i /etc/kubernetes/admin.conf \$HOME/.kube/config
+sudo chown \$(id -u):\$(id -g) \$HOME/.kube/config
 kubectl apply -f /opt/weave-kube
 /opt/create-pv.sh
 EOF

--- a/environments/crunchydata-k8s-centos/master/build/99_cleanup.sh
+++ b/environments/crunchydata-k8s-centos/master/build/99_cleanup.sh
@@ -1,4 +1,0 @@
-rm -f ~/.kube/config; sudo rm -f /root/.kube/config; sudo rm -f /var/lib/dbus/machine-id; sudo rm -f /etc/machine-id; sudo rm -f /etc/weave/machine-uuid; sudo rm -f /etc/.regen-machine-id; sudo rm -f /root/.bash_history; sudo rm -f /home/ubuntu/.bash_history; sudo rm -f /etc/docker/key.json; sudo systemctl stop kubelet; sudo find /var/lib/kubelet | xargs -n 1 findmnt -n -t tmpfs -o TARGET -T | uniq | xargs -r sudo umount -v; sudo rm -r -f /etc/kubernetes /var/lib/kubelet /var/lib/etcd /etc/cni/net.d/* /var/lib/dockershim; true
-
-sudo dbus-uuidgen --ensure
-sudo dbus-uuidgen > /etc/machine-id

--- a/environments/crunchydata-k8s-centos/master/katacoda.yaml
+++ b/environments/crunchydata-k8s-centos/master/katacoda.yaml
@@ -1,1 +1,1 @@
-base: 'centos7'
+base: 'kubernetes-master-centos7-1-16'

--- a/environments/crunchydata-k8s-centos/node01/build/1_k8s_node.sh
+++ b/environments/crunchydata-k8s-centos/node01/build/1_k8s_node.sh
@@ -1,4 +1,10 @@
 set -e
+sudo rpm --import https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+sudo yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+if [ "$?" -ne 0 ]; then
+    echo "Unable to install Postgres Repo"
+    exit 1
+fi
 
 sudo yum install -y postgresql12
 

--- a/environments/crunchydata-k8s-centos/node01/build/1_k8s_node.sh
+++ b/environments/crunchydata-k8s-centos/node01/build/1_k8s_node.sh
@@ -1,50 +1,8 @@
 set -e
-sudo yum remove -y docker docker-common
 
-sudo rpm --import https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
-sudo yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-if [ "$?" -ne 0 ]; then
-    echo "Unable to install Postgres Repo"
-    exit 1
-fi
+sudo yum install -y postgresql12
 
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum install -y docker-ce docker-ce-cli containerd.io unzip nano postgresql12
-systemctl enable --now docker
-systemctl start docker
-
-echo '127.0.0.1 node01' >> /etc/hosts
-hostname node01 && echo node01 > /etc/hostname
-hostnamectl set-hostname node01
-
-cat <<EOF > /etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-exclude=kube*
-EOF
-
-# Set SELinux in permissive mode (effectively disabling it)
-setenforce 0
-sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
-
-yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
-
-systemctl enable --now kubelet
-
-cat <<EOF >  /etc/sysctl.d/k8s.conf
-net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-EOF
-sysctl --system
-sudo kubeadm config images pull
-sudo docker pull weaveworks/weave-kube:2.5.1
-sudo docker pull weaveworks/weave-npc:2.5.1
+sudo docker pull storageos/node:1.5.0
 
 #now operator stuff
 

--- a/environments/crunchydata-k8s-centos/node01/build/99_cleanup.sh
+++ b/environments/crunchydata-k8s-centos/node01/build/99_cleanup.sh
@@ -1,4 +1,0 @@
-rm -f ~/.kube/config; sudo rm -f /root/.kube/config; sudo rm -f /var/lib/dbus/machine-id; sudo rm -f /etc/machine-id; sudo rm -f /etc/weave/machine-uuid; sudo rm -f /etc/.regen-machine-id; sudo rm -f /root/.bash_history; sudo rm -f /home/ubuntu/.bash_history; sudo rm -f /etc/docker/key.json; sudo systemctl stop kubelet; sudo find /var/lib/kubelet | xargs -n 1 findmnt -n -t tmpfs -o TARGET -T | uniq | xargs -r sudo umount -v; sudo rm -r -f /etc/kubernetes /var/lib/kubelet /var/lib/etcd /etc/cni/net.d/* /var/lib/dockershim; true
-
-sudo dbus-uuidgen --ensure
-sudo dbus-uuidgen > /etc/machine-id

--- a/environments/crunchydata-k8s-centos/node01/katacoda.yaml
+++ b/environments/crunchydata-k8s-centos/node01/katacoda.yaml
@@ -1,1 +1,1 @@
-base: 'centos7'
+base: 'kubernetes-node-centos7-1-16'


### PR DESCRIPTION
This will pin the version to 1.16 and let you focus on your config instead of Kubernetes.

/cc @gsoria can you double check as well please