### PR TITLE
added "start scenario" action to postgis pathway

### DIFF
--- a/postgis-pathway.json
+++ b/postgis-pathway.json
@@ -2,42 +2,52 @@
   "title": "CrunchyData PostGIS",
   "courses": [
     {
+      "action" : "Start Scenario",
       "external_link": "https://learn.crunchydata.com/postgis/qpostgisintro/",
       "course_id": "qpostgisintro",
       "title": "0 - Quick Introduction To PostGIS"
     },{
+      "action" : "Start Scenario",
       "external_link": "https://learn.crunchydata.com/postgis/geometries/",
       "course_id": "geometries",
       "title": "1 - Geometries"
     },{
+      "action" : "Start Scenario",
       "external_link": "https://learn.crunchydata.com/postgis/geography/",
       "course_id": "geography",
       "title": "2 - Geography"
     },{
+      "action" : "Start Scenario",
       "external_link": "https://learn.crunchydata.com/postgis/projection/",
       "course_id": "projection",
       "title": "3 - Projection"
     },{
+      "action" : "Start Scenario",
       "external_link": "https://learn.crunchydata.com/postgis/spatial_relationships/",
       "course_id": "spatial_relationships",
       "title": "4 - Spatial Relationships"
     },{
+      "action" : "Start Scenario",
       "external_link": "https://learn.crunchydata.com/postgis/geom_functions/",
       "course_id": "geom_functions",
       "title": "5 - Geometry Constructing Functions"
     },{
+      "action" : "Start Scenario",
       "external_link": "https://learn.crunchydata.com/postgis/joins/",
       "course_id": "joins",
       "title": "6 - Spatial Joins"
     },{
+      "action" : "Start Scenario",
       "external_link": "https://learn.crunchydata.com/postgis/joins_advanced/",
       "course_id": "joins_advanced",
       "title": "7 - Advanced Spatial Joins"
     },{
+      "action" : "Start Scenario",
       "external_link": "https://learn.crunchydata.com/postgis/indexing/",
       "course_id": "indexing",
       "title": "8 - Spatial Indexing"
     },{
+      "action" : "Start Scenario",
       "external_link": "https://learn.crunchydata.com/postgis/pg_featureserv/",
       "course_id": "pg_featureserv",
       "title": "9 - Creating Spatial Features with pg_featureserv"


### PR DESCRIPTION
added missing "action" tags to the postgis-pathway file. This will fix the missing "start scenario" button on pg_featureserv and be more consistent with the other scenario pages on the site.