### PR TITLE
Temporary fix for course list display bug

### DIFF
--- a/branded-ui/katacoda/templates/course.html
+++ b/branded-ui/katacoda/templates/course.html
@@ -22,7 +22,7 @@
           data-katacoda-color="linear-gradient(60deg, #279DD9, #1169B2)"
           data-katacoda-secondary="#fff"
           data-katacoda-font="Fort"
-          data-katacoda-fontheader="Fort" style="height:50rem;"
+          data-katacoda-fontheader="Fort" style="height:55rem;"
           data-katacoda-externalcss="http://{{.Site.VirtualHost}}/static/css/katacoda.css">
         </div>
       </div>

--- a/branded-ui/katacoda/templates/subcourse.html
+++ b/branded-ui/katacoda/templates/subcourse.html
@@ -22,7 +22,7 @@
           data-katacoda-color="linear-gradient(60deg, #279DD9, #1169B2)"
           data-katacoda-secondary="#fff"
           data-katacoda-font="Fort"
-          data-katacoda-fontheader="Fort" style="height:50rem;"
+          data-katacoda-fontheader="Fort" style="height:55rem;"
           data-katacoda-externalcss="http://{{.Site.VirtualHost}}/static/css/katacoda.css">
         </div>
       </div>


### PR DESCRIPTION
Reaching out to Katacoda support to determine a more viable workaround than overriding their manually-defined height for the Katacoda `<embed>`. This is a temporary fix in the meantime for the sake of current display on production.