### PR TITLE
Fix broken link

### DIFF
--- a/branded-ui/katacoda/templates/navigation.html
+++ b/branded-ui/katacoda/templates/navigation.html
@@ -21,7 +21,7 @@
                             <a class="dropdown-item" href="https://www.crunchydata.com/products/crunchy-postgresql-for-kubernetes/">
                                 Crunchy PostgreSQL for Kubernetes
                             </a>
-                            <a class="dropdown-item" href="https://www.crunchydata.com/products/crunchy-postgresql-cloud-foundry/">
+                            <a class="dropdown-item" href="https://www.crunchydata.com/products/crunchy-postgresql-for-cloud-foundry/">
                                 Crunchy PostgreSQL for Cloud Foundry
                             </a>
                             <a class="dropdown-item" href="https://www.crunchydata.com/products/crunchy-postgresql-high-availability-suite/">


### PR DESCRIPTION
I wasn't able to test this locally. The build instructions didn't not work for me but I just updated this link to point to this page on our site:

https://www.crunchydata.com/products/crunchy-postgresql-for-cloud-foundry/